### PR TITLE
Disable short reads when chunked (fixes #28)

### DIFF
--- a/sseclient.py
+++ b/sseclient.py
@@ -65,12 +65,13 @@ class SSEClient(object):
             while True:
                 if hasattr(self.resp.raw, '_fp') and \
                         hasattr(self.resp.raw._fp, 'fp') and \
-                        hasattr(self.resp.raw._fp.fp, 'read1'):
+                        hasattr(self.resp.raw._fp.fp, 'read1') and \
+                        not self.resp.raw.chunked:
                     chunk = self.resp.raw._fp.fp.read1(self.chunk_size)
                 else:
-                    # _fp is not available, this means that we cannot use short
-                    # reads and this will block until the full chunk size is
-                    # actually read
+                    # _fp is not available or we are using chunked encoding
+                    # this means that we cannot use short reads and this will
+                    # block until the full chunk size is actually read
                     chunk = self.resp.raw.read(self.chunk_size)
                 if not chunk:
                     break


### PR DESCRIPTION
When chunked transfer encoding is used, the size of the chunk is
prepended to each chunk. When calling read1 on the raw file-pointer,
this data is not stripped off and breaks the JSON formatting.